### PR TITLE
Updates to Easy Hub deployment

### DIFF
--- a/src/cluster_cf.yaml
+++ b/src/cluster_cf.yaml
@@ -292,7 +292,7 @@ Resources:
     - ControlPlaneSecurityGroup
     Properties:
       Name: !Sub "umsi-easy-hub-${Tag}-EksCluster"
-      # Can we just reference the role from above?
+      Version: "1.19"
       RoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/${AWS::StackName}-eks-control-plane-role"
       ResourcesVpcConfig:
         SecurityGroupIds: [!Ref ControlPlaneSecurityGroup]

--- a/src/cluster_cf.yaml
+++ b/src/cluster_cf.yaml
@@ -14,11 +14,11 @@ Parameters:
   Subnet01Id:
     Type: String
     Description: Id of subnet 01
-  
+
   Subnet02Id:
     Type: String
     Description: Id of subnet 02
-  
+
   Subnet03Id:
     Type: String
     Description: Id of subnet 03
@@ -27,11 +27,11 @@ Parameters:
     Type: String
     Description: Tag used for billing monitoring
     Default: jupyterhub
-  
+
   ScriptBucket:
     Type: String
     Description: Bucket that stores startup scripts used by Cluster instances
-  
+
   ControlNodeSecurityGroup:
     Type: AWS::EC2::SecurityGroup::Id
     Description: Security groud of control node
@@ -40,41 +40,41 @@ Parameters:
     Type: String
     Description: Default port to forward http traffic to on the nodes
     Default: 30254
-  
+
   DefaultAlbForwardPortHttps:
     Type: String
     Description: Default port to forward https traffic to on the nodes
     Default: 30255
-  
+
   ScaleOutPolicyTargetValue:
     Type: Number
     Description: Target average cpu utilization for cluster nodes
     Default: 60
-  
+
   KeyName:
     Description: The EC2 Key Pair to allow SSH access to the master and node instances
     Type: AWS::EC2::KeyPair::KeyName
-  
+
   NodeImageId:
     Type: AWS::EC2::Image::Id
     Description: AMI id for the node instances.
     Default: "ami-0c24db5df6badc35a"
-  
+
   NodeInstanceType:
     Description: EC2 instance type for the node instances
     Type: String
     Default: t3.xlarge
-  
+
   NodeInstanceMem:
     Description: EC2 instance memory (in Gb)
     Type: Number
     Default: 16
-  
+
   UserPodMem:
     Description: Amount of memory to assign to each user pod
     Type: Number
     Default: 4
-  
+
   DesiredPodBuffer:
     Description: Amount of pods on standby ready to take users
     Type: Number
@@ -106,7 +106,7 @@ Parameters:
     Type: String
 
 Resources:
-  
+
   EFS:
     Type: AWS::EFS::FileSystem
     DeletionPolicy: Retain
@@ -114,7 +114,7 @@ Resources:
       FileSystemTags:
         - Key: Name
           Value: !Sub umsi-easy-hub-${Tag}-efs
-  
+
   Subnet01EfsMountTarget:
     Type: AWS::EFS::MountTarget
     Properties:
@@ -125,7 +125,7 @@ Resources:
       SecurityGroups:
         - Ref: ControlNodeSecurityGroup
         - Ref: NodeSecurityGroup
-  
+
   Subnet02EfsMountTarget:
     Type: AWS::EFS::MountTarget
     Properties:
@@ -136,7 +136,7 @@ Resources:
       SecurityGroups:
         - Ref: ControlNodeSecurityGroup
         - Ref: NodeSecurityGroup
-  
+
   Subnet03EfsMountTarget:
     Type: AWS::EFS::MountTarget
     Properties:
@@ -180,7 +180,7 @@ Resources:
   #         Ref: Alb
   #     Port: 443
   #     Protocol: HTTPS
-  
+
   AlbListenerHttp:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
@@ -188,11 +188,11 @@ Resources:
         - Type: forward
           TargetGroupArn:
             Ref: AlbTargetGroupHttp
-      LoadBalancerArn: 
+      LoadBalancerArn:
           Ref: Alb
       Port: 80
       Protocol: HTTP
-  
+
   AlbTargetGroupHttps:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
@@ -204,7 +204,7 @@ Resources:
       Protocol: HTTPS
       VpcId:
         Ref: VpcId
-  
+
   AlbTargetGroupHttp:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
@@ -233,7 +233,7 @@ Resources:
     Properties:
       GroupDescription: Cluster communication with worker nodes
       VpcId: !Ref VpcId
-  
+
   ControlPlaneSecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: NodeSecurityGroup
@@ -244,7 +244,7 @@ Resources:
       IpProtocol: tcp
       ToPort: 443
       FromPort: 443
-  
+
   ControlPlaneEgressToNodeSecurityGroup:
     Type: AWS::EC2::SecurityGroupEgress
     DependsOn: NodeSecurityGroup
@@ -255,7 +255,7 @@ Resources:
       IpProtocol: tcp
       FromPort: 1025
       ToPort: 65535
-  
+
   ControlPlaneEgressToNodeSecurityGroupOn443:
     Type: AWS::EC2::SecurityGroupEgress
     DependsOn: NodeSecurityGroup
@@ -284,10 +284,10 @@ Resources:
       - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
       - arn:aws:iam::aws:policy/AmazonEKSServicePolicy
       RoleName: !Sub '${AWS::StackName}-eks-control-plane-role'
-  
+
   EksCluster:
     Type: "AWS::EKS::Cluster"
-    DependsOn: 
+    DependsOn:
     - EksControlPlaneRole
     - ControlPlaneSecurityGroup
     Properties:
@@ -339,7 +339,7 @@ Resources:
             Effect: "Allow"
             Action:
               - "elasticloadbalancing:*"
-            Resource: "*" 
+            Resource: "*"
       Roles:
         -
           Ref: NodeInstanceRole
@@ -349,11 +349,11 @@ Resources:
     Properties:
       GroupDescription: Security group for all nodes in the cluster
       VpcId:
-        !Ref VpcId  
+        !Ref VpcId
       Tags:
       - Key: !Sub "kubernetes.io/cluster/umsi-easy-hub-${Tag}-EksCluster"
         Value: 'owned'
-  
+
   NodeSecurityGroupMasterElbIngress:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: NodeSecurityGroup
@@ -364,7 +364,7 @@ Resources:
       IpProtocol: '-1'
       FromPort: 0
       ToPort: 65535
-  
+
   NodeSecurityGroupControlNodeIngress:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: NodeSecurityGroup
@@ -375,7 +375,7 @@ Resources:
       IpProtocol: '-1'
       FromPort: 0
       ToPort: 65535
-  
+
   NodeSecurityGroupElbIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
@@ -385,7 +385,7 @@ Resources:
       IpProtocol: '-1'
       FromPort: 0
       ToPort: 65535
-  
+
   NodeSecurityGroupFromControlPlaneIngress:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: NodeSecurityGroup
@@ -396,7 +396,7 @@ Resources:
       IpProtocol: tcp
       FromPort: 1025
       ToPort: 65535
-  
+
   NodeSecurityGroupFromControlPlaneOn443Ingress:
     Type: AWS::EC2::SecurityGroupIngress
     DependsOn: NodeSecurityGroup
@@ -450,7 +450,7 @@ Resources:
       Statistic: Minimum
       Threshold: 1
       Namespace: Custom
-  
+
   ScaleOutPolicy:
     Type: AWS::AutoScaling::ScalingPolicy
     Properties:
@@ -486,7 +486,7 @@ Resources:
                      --stack  ${AWS::StackName} \
                      --resource NodeAsg  \
                      --region ${AWS::Region}
-            
+
             cd /home/ec2-user/
 
             aws s3 cp s3://${ScriptBucket}/node_startup_script.sh node_startup_script.sh
@@ -504,15 +504,15 @@ Outputs:
   Tag:
     Description: Tag
     Value: !Ref Tag
-  
+
   EksName:
     Description: Name of EKS backplane
     Value: !Sub umsi-easy-hub-${Tag}-EksCluster
-  
+
   NodeRoleArn:
     Description: ARN of node role
     Value: !GetAtt NodeInstanceRole.Arn
-  
+
   Asg:
     Description: Name of the autoscaling group created
     Value: !Ref NodeAsg

--- a/src/cluster_cf.yaml
+++ b/src/cluster_cf.yaml
@@ -292,7 +292,6 @@ Resources:
     - ControlPlaneSecurityGroup
     Properties:
       Name: !Sub "umsi-easy-hub-${Tag}-EksCluster"
-      Version: "1.12"
       # Can we just reference the role from above?
       RoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/${AWS::StackName}-eks-control-plane-role"
       ResourcesVpcConfig:

--- a/src/control_node_cf.yaml
+++ b/src/control_node_cf.yaml
@@ -20,10 +20,6 @@ Parameters:
     Description: The EC2 Key Pair to allow SSH access to the master and node instances
     Type: AWS::EC2::KeyPair::KeyName
 
-  PrivateKey:
-    Type: String
-    Description: The contents of the private SSH key
-
 Resources:
   VPC:
     Type: AWS::EC2::VPC
@@ -213,7 +209,7 @@ Resources:
     Type: "AWS::SecretsManager::Secret"
     Properties:
       Name: !Sub "${KeyName}.pem"
-      SecretString: !Ref PrivateKey
+      SecretString: "not yet uploaded"
       Description: !Sub "SSH Key for the ${AWS::StackName} CloudFormation stack"
       Tags:
       - Key: Purpose

--- a/src/control_node_cf.yaml
+++ b/src/control_node_cf.yaml
@@ -20,6 +20,10 @@ Parameters:
     Description: The EC2 Key Pair to allow SSH access to the master and node instances
     Type: AWS::EC2::KeyPair::KeyName
 
+  PrivateKey:
+    Type: String
+    Description: The contents of the private SSH key
+
 Resources:
   VPC:
     Type: AWS::EC2::VPC
@@ -205,6 +209,16 @@ Resources:
 
             su ec2-user -c './control_node_startup_script.sh "${AWS::StackName}" "${Tag}" "${ScriptBucket}"'
 
+  SSHKey:
+    Type: "AWS::SecretsManager::Secret"
+    Properties:
+      Name: !Sub "${KeyName}.pem"
+      SecretString: !Ref PrivateKey
+      Description: !Sub "SSH Key for the ${AWS::StackName} CloudFormation stack"
+      Tags:
+      - Key: Purpose
+        Value: !Ref BillingTag
+
 Outputs:
 
   Tag:
@@ -242,3 +256,7 @@ Outputs:
   ControlNodeSecurityGroup:
     Description: The control node security group created in this stack
     Value: !Ref ControlNodeSecurityGroup
+
+  Instance:
+    Description: The control node instance
+    Value: !Ref ControlNode

--- a/src/control_node_cf.yaml
+++ b/src/control_node_cf.yaml
@@ -11,11 +11,11 @@ Parameters:
     Type: String
     Description: Tag used for billing monitoring
     Default: jupyterhub
-  
+
   ScriptBucket:
     Type: String
     Description: Bucket that stores startup scripts used by Cluster instances
-  
+
   KeyName:
     Description: The EC2 Key Pair to allow SSH access to the master and node instances
     Type: AWS::EC2::KeyPair::KeyName
@@ -130,9 +130,9 @@ Resources:
     Properties:
       SubnetId: !Ref Subnet03
       RouteTableId: !Ref RouteTable
-  
+
   ControlNodeSecurityGroup:
-  # This is a very open SG!!  
+  # This is a very open SG!!
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
       GroupDescription: Control node security group
@@ -172,7 +172,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AdministratorAccess
       RoleName: !Sub 'umsi-easy-hub-${Tag}-control-node-role'
-  
+
   ControlNode:
     Type: "AWS::EC2::Instance"
     Properties:
@@ -214,11 +214,11 @@ Outputs:
   Subnet01Id:
     Description: All subnets in the VPC
     Value: !Ref Subnet01
-  
+
   Subnet02Id:
     Description: All subnets in the VPC
     Value: !Ref Subnet02
-  
+
   Subnet03Id:
     Description: All subnets in the VPC
     Value: !Ref Subnet03
@@ -230,7 +230,7 @@ Outputs:
   KeyName:
     Description: The name of the ssh key used
     Value: !Ref KeyName
-  
+
   ScriptBucket:
     Description: The name of the bucket that holds all the scripts
     Value: !Ref ScriptBucket
@@ -238,7 +238,7 @@ Outputs:
   BillingTag:
     Description: The billing tag
     Value: !Ref BillingTag
-  
+
   ControlNodeSecurityGroup:
     Description: The control node security group created in this stack
     Value: !Ref ControlNodeSecurityGroup

--- a/src/control_node_startup_script.sh
+++ b/src/control_node_startup_script.sh
@@ -36,7 +36,7 @@ aws s3 cp s3://${SCRIPT_BUCKET}/helm_config.yaml .
 
 # Fetch the SSH key from the secret store
 aws secretsmanager get-secret-value --secret-id umsi-easy-hub-${TAG}.pem \
-  --query SecretString --output text > umsi-easy-hub-${TAG}.pem
+  --query SecretString --output text --region us-east-1 > umsi-easy-hub-${TAG}.pem
 
 # Install packages
 sudo yum install python37 python37-pip -y
@@ -99,6 +99,7 @@ helm repo update
 export RELEASE=jhub
 export NAMESPACE=jhub
 JUPYTERHUB_IMAGE="jupyterhub/jupyterhub"
+kubectl create namespace $NAMESPACE
 helm upgrade --install $RELEASE $JUPYTERHUB_IMAGE --namespace $NAMESPACE --version 0.8.2 --values helm_config.yaml
 
 # Add in autoscaler

--- a/src/control_node_startup_script.sh
+++ b/src/control_node_startup_script.sh
@@ -24,15 +24,7 @@ export HOME=/home/ec2-user/
 export PATH=/usr/local/bin/:$PATH && echo "export PATH=/usr/local/bin/:$PATH" >> ~/.bashrc
 
 # Download files from s3
-aws s3 cp s3://${SCRIPT_BUCKET}/config.yaml .
-aws s3 cp s3://${SCRIPT_BUCKET}/control_node_startup_script.sh .
-aws s3 cp s3://${SCRIPT_BUCKET}/cluster_cf.yaml .
-aws s3 cp s3://${SCRIPT_BUCKET}/deploy_cluster_cf.py .
-aws s3 cp s3://${SCRIPT_BUCKET}/autoscale_daemon.py .
-aws s3 cp s3://${SCRIPT_BUCKET}/generate_hex.py .
-aws s3 cp s3://${SCRIPT_BUCKET}/set_pod_memory.py .
-aws s3 cp s3://${SCRIPT_BUCKET}/get_cluster_cf_output.py .
-aws s3 cp s3://${SCRIPT_BUCKET}/helm_config.yaml .
+aws s3 cp --recursive s3://${SCRIPT_BUCKET}/ .
 
 # Fetch the SSH key from the secret store
 aws secretsmanager get-secret-value --secret-id umsi-easy-hub-${TAG}.pem \

--- a/src/control_node_startup_script.sh
+++ b/src/control_node_startup_script.sh
@@ -30,11 +30,14 @@ aws s3 cp s3://${SCRIPT_BUCKET}/control_node_startup_script.sh .
 aws s3 cp s3://${SCRIPT_BUCKET}/cluster_cf.yaml .
 aws s3 cp s3://${SCRIPT_BUCKET}/deploy_cluster_cf.py .
 aws s3 cp s3://${SCRIPT_BUCKET}/autoscale_daemon.py .
-aws s3 cp s3://${SCRIPT_BUCKET}/umsi-easy-hub-${TAG}.pem .
 aws s3 cp s3://${SCRIPT_BUCKET}/generate_hex.py .
 aws s3 cp s3://${SCRIPT_BUCKET}/set_pod_memory.py .
 aws s3 cp s3://${SCRIPT_BUCKET}/get_cluster_cf_output.py .
 aws s3 cp s3://${SCRIPT_BUCKET}/helm_config.yaml .
+
+# Fetch the SSH key from the secret store
+aws secretsmanager get-secret-value --secret-id umsi-easy-hub-${TAG}.pem \
+  --query SecretString --output text > umsi-easy-hub-${TAG}.pem
 
 # Install packages
 sudo yum install python37 python37-pip -y

--- a/src/control_node_startup_script.sh
+++ b/src/control_node_startup_script.sh
@@ -91,6 +91,8 @@ helm repo update
 export RELEASE=jhub
 export NAMESPACE=jhub
 JUPYTERHUB_IMAGE="jupyterhub/jupyterhub"
+
+# Create namespace because helm expects it to exist already.
 kubectl create namespace $NAMESPACE
 helm upgrade --install $RELEASE $JUPYTERHUB_IMAGE --namespace $NAMESPACE --version 0.8.2 --values helm_config.yaml
 

--- a/src/deploy_cluster_cf.py
+++ b/src/deploy_cluster_cf.py
@@ -35,7 +35,7 @@ def get_cf_output(config):
     output = {}
     for item in response['Stacks'][0]['Outputs']:
         output[item['OutputKey']] = item['OutputValue']
-    
+
     config.update(output)
     # config['tag'] = 'test'
 


### PR DESCRIPTION
These are some changes I made while playing around with easy hub. Addresses https://github.com/umsi-mads/main/issues/336

* Separate SSH key into a secret rather than S3 upload
* Make the secret part of the cloud formation stack so that it's cleaned up on deletion
* Add `--wait` flag to wait until the stack is deployed
* Fix `autoscale_daemon.py`, which appeared to not be working at all
* Remove hard-coded Kubernetes version. The version previously stated is no longer allowed.
* Upgrade to Helm 3

I think the helm upgrade is the most volatile thing, but it seems to work without issue. Helm 3 removes the need for the tiller role, so this cleans things up a bit. We also need to keep this updated to prevent stagnation here.