### PR TITLE
Update the ami to be compatible with EKS Kube 1.18 and above

### DIFF
--- a/src/cluster_cf.yaml
+++ b/src/cluster_cf.yaml
@@ -58,7 +58,7 @@ Parameters:
   NodeImageId:
     Type: AWS::EC2::Image::Id
     Description: AMI id for the node instances.
-    Default: "ami-0c24db5df6badc35a"
+    Default: "ami-0c385d0d99fce057d"
 
   NodeInstanceType:
     Description: EC2 instance type for the node instances
@@ -292,7 +292,7 @@ Resources:
     - ControlPlaneSecurityGroup
     Properties:
       Name: !Sub "umsi-easy-hub-${Tag}-EksCluster"
-      Version: "1.19"
+      Version: "1.21"
       RoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/${AWS::StackName}-eks-control-plane-role"
       ResourcesVpcConfig:
         SecurityGroupIds: [!Ref ControlPlaneSecurityGroup]

--- a/src/control_node_startup_script.sh
+++ b/src/control_node_startup_script.sh
@@ -55,7 +55,7 @@ output=($(python3 get_cluster_cf_output.py --cluster-stackname "umsi-easy-hub-${
 # ${output[3]} = Asg
 
 # Get kubectl binary which will expose control plane configuration options
-curl -o kubectl https://amazon-eks.s3-us-west-2.amazonaws.com/1.11.5/2018-12-06/bin/linux/amd64/kubectl
+curl -o kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/kubectl
 chmod +x ./kubectl
 sudo cp ./kubectl /usr/local/bin/kubectl
 


### PR DESCRIPTION
The issue here was a mismatch between the ami we were using for the
self-managed nodes.
That ami worked OK up to EKS with Kube 1.18 and started failing with
Kube 1.19 and up with a cryptic error about issues with the CNI plugin
(the nodes were missing some config files although I suspect they were
missing some other things as well since replacing CNI with Calico did
not work either).

I have also updated the CF file to use the latest available Kube (1.21)
and updated the script installing a kubectl matching the version (it is
important to keep both in sync to prevent issues accordingly to the docs - 
and I verified myself lacking output from an old kubectl).